### PR TITLE
Fix false positive in CRLF injection detection for 302 redirects

### DIFF
--- a/cRlf.yaml
+++ b/cRlf.yaml
@@ -2,7 +2,7 @@ id: crlf-injection-extended
 
 info:
   name: CRLF Injection Extended Detection
-  author: coffin
+  author: coffin, Psikoz
   severity: high
   description: Detects a wide range of CRLF injection vectors that can be exploited for header injection, response splitting, and XSS.
   reference:
@@ -49,7 +49,6 @@ http:
       - type: regex
         part: header
         regex:
-          - '(?i)(location\s*:\s*(http[s]?:)?//?www\.evil\.com)'
           - '(?i)(set-cookie\s*:\s*coffin\s*=\s*hi)'
           - '(?i)(coffin-x\s*:\s*coffin-x)'
       - type: status
@@ -61,6 +60,14 @@ http:
           - 205
           - 206
           - 207
+        condition: or
+      - type: regex
+        part: header
+        regex:
+          - '(?i)location\s*:\s*(http[s]?:)?//?www\.evil\.com'
+        condition: and
+      - type: status
+        status:
           - 301
           - 302
           - 307


### PR DESCRIPTION
## Problem
The CRLF injection template was generating false positives when domains returned legitimate 302 redirects. The matcher was incorrectly flagging normal redirect responses as CRLF injection vulnerabilities.

## Solution
- Separated location header detection from other CRLF injection indicators
- Split status code matching into two conditions:
  - Non-redirect responses (200-207) for Set-Cookie/custom header injection
  - Redirect responses (301/302/307/308) specifically for malicious location header injection
- Added proper condition logic to prevent false positives on legitimate redirects

## Changes
- Modified matcher conditions to be more specific
- Improved detection accuracy by requiring both malicious location header AND redirect status code
- Maintained detection capability for all other CRLF injection vectors